### PR TITLE
Fix Link to Contribution Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ make install
 If you want to contribute to the project, a few more steps are required to make the project ready
 for development.
 
-Please head to the [Contributing Guide](https://DAI-Lab.github.io/RivaGAN/contributing.html#get-started)
+Please head to the [Contributing Guide](./CONTRIBUTING.rst)
 for more details about this process.
 
 # Quickstart


### PR DESCRIPTION
Replaced link points to: https://dai-lab.github.io/RivaGAN/contributing.html#get-started